### PR TITLE
using rstrip before breaking up into parts

### DIFF
--- a/nb2plots/nbplots.py
+++ b/nb2plots/nbplots.py
@@ -806,7 +806,7 @@ def parse_parts(lines):
         ``contents``, with value being a list of strings, one string per line.
         The other key, value pairs are attributes of this part.
     """
-    text = '\n'.join(lines).strip()
+    text = '\n'.join(lines).rstrip()
     part_strs = PARTER.split(text)
     if len(part_strs) == 1:
         return [{'contents': part_strs[0].splitlines()}]


### PR DESCRIPTION
using rstrip instead of strip maintains indentation level  of entire literal block, though would not strip newlines from beginning of content;

addresses (small) issue https://github.com/matthew-brett/nb2plots/issues/11