### PR TITLE
Fix non-raw strings containing escape characters

### DIFF
--- a/nb2plots/from_notebook.py
+++ b/nb2plots/from_notebook.py
@@ -88,8 +88,8 @@ def to_doctests(code, first='>>> ', cont='... '):
     return '\n'.join(new_code)
 
 
-MPL_LIST_OUT = re.compile('\[<matplotlib\..*?>\]')
-MPL_OBJ_OUT = re.compile('<matplotlib\..*?>')
+MPL_LIST_OUT = re.compile(r'\[<matplotlib\..*?>\]')
+MPL_OBJ_OUT = re.compile(r'<matplotlib\..*?>')
 
 def ellipse_mpl(text):
     """ Replace outputs of matplotlib objects with ellipses
@@ -113,11 +113,11 @@ CODE_WITH_OUTPUT = re.compile(
     '^##CODE_START##\n'
     '(?P<code>.*?)'
     '^##CODE_END##(\n|$)'
-    '([\s\\n]*?'
+    '([\\s\\n]*?'
     '^##STDOUT_START##\n'
     '(?P<stdout>.*?)'
     '^##STDOUT_END##(\n|$))?'
-    '([\s\\n]*?'
+    '([\\s\\n]*?'
     '^##END_OUT_START##\n'
     '(?P<end_out>.*?)'
     '^##END_OUT_END##(\n|$))?', re.S | re.M)

--- a/nb2plots/nbplots.py
+++ b/nb2plots/nbplots.py
@@ -673,7 +673,7 @@ def remove_coding(text):
     """
     Remove the coding comment, which six.exec_ doesn't like.
     """
-    sub_re = re.compile("^#\s*-\*-\s*coding:\s*.*-\*-$", flags=re.MULTILINE)
+    sub_re = re.compile(r"^#\s*-\*-\s*coding:\s*.*-\*-$", flags=re.MULTILINE)
     return sub_re.sub("", text)
 
 #------------------------------------------------------------------------------

--- a/nb2plots/tests/test_builders.py
+++ b/nb2plots/tests/test_builders.py
@@ -120,8 +120,7 @@ class TestBasedMarkdownBuild(TestMarkdownBuild):
 
     def test_output(self):
         assert self.get_built_file('contents.md').strip() == ''
-        expected_re = """\
-## Refereed section
+        expected_re = r"""## Refereed section
 
 This section refers to \[itself\]\(https://dynevor.org/a_page.html#a-ref\)\.
 

--- a/nb2plots/tests/test_codelinks.py
+++ b/nb2plots/tests/test_codelinks.py
@@ -20,8 +20,7 @@ Text here
 .. code-links::
 
 More text here."""
-    both_re = re.compile("""\
-<document source=".*?">
+    both_re = re.compile(r"""<document source=".*?">
     <paragraph>
         Text here
     <code_links>
@@ -61,8 +60,7 @@ Text here
 
 More text here."""
     pxml = as_pxml(page)
-    assert re.match("""\
-<document source=".*?">
+    assert re.match(r"""<document source=".*?">
     <paragraph>
         Text here
     <code_links>
@@ -81,8 +79,7 @@ Text here
 
 More text here."""
     pxml = as_pxml(page)
-    assert re.match("""\
-<document source=".*?">
+    assert re.match(r"""<document source=".*?">
     <paragraph>
         Text here
     <code_links>
@@ -101,8 +98,7 @@ Text here
 
 More text here."""
     pxml = as_pxml(page)
-    assert re.match("""\
-<document source=".*?">
+    assert re.match(r"""<document source=".*?">
     <paragraph>
         Text here
     <code_links>

--- a/nb2plots/tests/test_runroles.py
+++ b/nb2plots/tests/test_runroles.py
@@ -72,14 +72,14 @@ def test_runrole_doctrees():
         dict(code_type='clearnotebook',
              filebase='contents',
              base='/contents',
-             descr='Download this page as a Jupyter notebook \(no outputs\)'),
+             descr=r'Download this page as a Jupyter notebook \(no outputs\)'),
         "Text then :clearnotebook:`.` then text.")
     assert_rst_pxml(
         dict(code_type='fullnotebook',
              filebase='contents',
              base='/contents',
              descr=('Download this page as a Jupyter notebook '
-                    '\(with outputs\)')),
+                    r'\(with outputs\)')),
         "Text then :fullnotebook:`.` then text.")
     assert_rst_pxml(
         dict(code_type='pyfile',


### PR DESCRIPTION
This fixes python warnings about invalid escape sequences.  Check the change to CODE_WITH_OUTPUT in from_notebook.py; I am not certain that that is what is intended.  Also, changing the strings in test_builders.py and test_codelinks.py to raw strings unfortunately required removing the initial line-ending escape, which makes the code a little less pretty.  The alternative is to leave them as non-raw strings and double the other escape characters.