### PR TITLE
Import Sequence from either its new or its old location

### DIFF
--- a/nb2plots/nbplots.py
+++ b/nb2plots/nbplots.py
@@ -177,7 +177,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-from collections import defaultdict, Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
+from collections import defaultdict
 import sys, os, shutil, io, re, textwrap
 from os.path import (relpath, abspath, join as pjoin, dirname, exists,
                      basename, splitext, isdir)


### PR DESCRIPTION
This eliminates a warning from python 3.8.