### PR TITLE
Optionally render code output for nbplot directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ env:
         - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
 
 python:
-    - 3.4
     - 3.5
     - 3.6
+    - 3.7
+    - 3.8
 
 matrix:
   include:

--- a/nb2plots/nbplots.py
+++ b/nb2plots/nbplots.py
@@ -932,7 +932,7 @@ def run_code(code, code_path=None, ns=None, function_name=None, workdir=None,
                 mod = Module([node], [])
             elif mode == 'single':
                 mod = ast.Interactive([node])
-            exec(compile(mod, code_path, mode), ns)
+            six.exec_(compile(mod, '<dummyfile>', mode), ns)
 
     try:
         try:

--- a/nb2plots/nbplots.py
+++ b/nb2plots/nbplots.py
@@ -915,6 +915,8 @@ def run_code(code, code_path=None, ns=None, function_name=None, workdir=None,
             from ast import Module as OriginalModule
             Module = lambda nodelist, type_ignores: OriginalModule(nodelist)
         nodelist = ast.parse(excode).body
+        if not nodelist:
+            return
 
         if isinstance(nodelist[-1], ast.Expr):
             to_run_exec, to_run_interactive = nodelist[:-1], nodelist[-1:]

--- a/nb2plots/tests/test_nbplots.py
+++ b/nb2plots/tests/test_nbplots.py
@@ -40,15 +40,15 @@ def file_same(file1, file2):
 
 def test_run_code():
     # Test run_code function
-    ns1 = run_code('a = 10')
+    ns1, _, _ = run_code('a = 10')
     assert ns1['a'] == 10
     assert not 'b' in ns1
     # New namespace by default
-    ns2 = run_code('b = 20')
+    ns2, _, _ = run_code('b = 20')
     assert ns2['b'] == 20
     assert not 'a' in ns2
     # Adding to a namespace
-    ns3 = run_code('c = 30', ns=ns1)
+    ns3, _, _ = run_code('c = 30', ns=ns1)
     assert ns3 is ns1
     assert ns1['c'] == 30
     # Checking raises


### PR DESCRIPTION
This is controlled via the `nbplot_render_output` setting, which
defaults to `False`, thereby keeping previous behaviour.

I was also thinking of replacing the current `exec` mechanism with something that behaves more like the default repl shell, like printing the repr of single only-expression lines.  

If this feature is of interest to you I could use some pointers how to properly write a test for this.