### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,27 @@ matrix:
     - python: 3.5
       env:
           - DEPENDS="ipython[notebook] sphinx==1.7.6 matplotlib"
+# Adding ppc64le jobs
+    - python: 3.6
+      arch: ppc64le
+      env:
+        - DEPENDS=
+    - python: 3.5
+      arch: ppc64le
+      env:
+        - DOCTEST_ARGS="--doctest-modules"
+    - python: 3.5
+      arch: ppc64le
+      env:
+        - BUILD_DOC=1
+    # Test pre-release versions of everything
+    - python: 3.8
+      arch: ppc64le
+      env:
+        - EXTRA_PIP_FLAGS="--pre"
+    - python: 3.5
+      arch: ppc64le
+      env:
 
 before_install:
     - source tools/travis_tools.sh


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/nb2plots/builds/207957933

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj