### PR TITLE
Fix the expected regex for built HTML content

### DIFF
--- a/nb2plots/tests/test_nbplots.py
+++ b/nb2plots/tests/test_nbplots.py
@@ -452,7 +452,7 @@ See :ref:`the ref <a-ref>`.
         # Check that reference correctly included
         built = self.get_built_file('a_page.pseudoxml')
         expected_regexp = re.compile(
-r"""<document _plot_counter="1" source=".*?a_page.rst">
+r"""<document _plot_counter="1" source=".*?a_page.rst"( xmlns.*)?>
     <section ids="a-title" names="a\\ title">
         <title>
             A title


### PR DESCRIPTION
With new versions of components, this one test is failing because the generated HTML looks like this:
```
<document _plot_counter="1" source="/tmp/tmpxtllmjg7/source/a_page.rst" xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">
    <section ids="a-title" names="a\ title">
        <title>
            A title
        <target ids="a-ref" names="a-ref">
        <nbplot_container>
            <doctest_block classes="doctest" xml:space="preserve">
                >>> a = 1
        <nbplot_epilogue>
            <comment xml:space="preserve">
            <comment xml:space="preserve">
            <comment xml:space="preserve">
        <paragraph>
            See 
            <reference internal="True" refid="a-ref">
                <inline classes="std std-ref">
                    the ref
            .
```
I believe we don't need to check the `xmlns` attributes so the test basically ignores them now.