### PR TITLE
MRG: drop Python 2 compatibility

### DIFF
--- a/nb2plots/commands.py
+++ b/nb2plots/commands.py
@@ -7,11 +7,6 @@ from argparse import ArgumentParser
 from .converters import NbConverter
 
 
-def bin_stdout():
-    """ Bytes stream for writing to stdout """
-    return sys.stdout.buffer if sys.version_info[0] > 2 else sys.stdout
-
-
 def get_parser(description):
     """ Get parser for sphinx2something utilities
     """
@@ -33,4 +28,4 @@ def do_main(description, buildername):
                             status=sys.stderr,
                             warningiserror=args.warn_is_error)
     output = converter.from_rst(contents)
-    bin_stdout().write(output.encode('utf-8'))
+    sys.stdout.buffer().write(output.encode('utf-8'))

--- a/nb2plots/doctree2md.py
+++ b/nb2plots/doctree2md.py
@@ -6,7 +6,6 @@ See:
 * https://daringfireball.net/projects/markdown/syntax
 * https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf
 """
-from __future__ import unicode_literals
 
 import re
 from textwrap import dedent

--- a/nb2plots/doctree2nb.py
+++ b/nb2plots/doctree2nb.py
@@ -1,7 +1,5 @@
 """ Convert doctree to Jupyter notebook
 """
-from __future__ import unicode_literals
-
 from docutils import nodes
 
 from .ipython_shim import nbf

--- a/nb2plots/doctree2py.py
+++ b/nb2plots/doctree2py.py
@@ -1,6 +1,5 @@
 """ Writer to convert doctree to Python .py file
 """
-from __future__ import unicode_literals
 
 import re
 from textwrap import dedent

--- a/nb2plots/testing/__init__.py
+++ b/nb2plots/testing/__init__.py
@@ -15,12 +15,7 @@ DATA_PATH = abspath(pjoin(
 
 
 def setup_test():
-    """ Set numpy print options to "legacy" for new versions of numpy
-    """
-    from distutils.version import LooseVersion
-
-    if LooseVersion(np.__version__) >= LooseVersion('1.14'):
-        np.set_printoptions(legacy="1.13")
+    np.set_printoptions(legacy="1.13")
 
 
 class PlotsBuilder(SourcesBuilder):

--- a/nb2plots/tests/proj1/conf.py
+++ b/nb2plots/tests/proj1/conf.py
@@ -15,7 +15,6 @@
 import sys
 from os.path import join as pjoin, abspath
 import sphinx
-from distutils.version import LooseVersion
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -100,10 +99,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-if LooseVersion(sphinx.__version__) >= LooseVersion('1.3'):
-    html_theme = 'classic'
-else:
-    html_theme = 'default'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/nb2plots/tests/test_builders.py
+++ b/nb2plots/tests/test_builders.py
@@ -1,6 +1,5 @@
 """ Tests for Markdown and other builders
 """
-from __future__ import unicode_literals
 
 from os.path import join as pjoin, isfile
 import re

--- a/nb2plots/tests/test_doctree2md.py
+++ b/nb2plots/tests/test_doctree2md.py
@@ -4,8 +4,6 @@
 
 Test running writer over example files and chosen snippets
 """
-from __future__ import (division, print_function, absolute_import,
-                        unicode_literals)
 
 import sys
 from os.path import join as pjoin

--- a/nb2plots/tests/test_doctree2py.py
+++ b/nb2plots/tests/test_doctree2py.py
@@ -2,8 +2,6 @@
 
 Test running writer over example files and chosen snippets.
 """
-from __future__ import (division, print_function, absolute_import,
-                        unicode_literals)
 
 from os.path import join as pjoin
 from glob import glob

--- a/nb2plots/tests/test_nbplots.py
+++ b/nb2plots/tests/test_nbplots.py
@@ -1,5 +1,4 @@
 """ Tests for build using nbplot extension """
-from __future__ import unicode_literals
 
 from os.path import (join as pjoin, dirname, isdir)
 import re

--- a/nb2plots/tests/test_scripts.py
+++ b/nb2plots/tests/test_scripts.py
@@ -4,7 +4,6 @@
 
 Test running scripts
 """
-from __future__ import division, print_function, absolute_import
 
 from os.path import (join as pjoin, exists)
 from glob import glob

--- a/nb2plots/tests/test_sphinx2md.py
+++ b/nb2plots/tests/test_sphinx2md.py
@@ -2,8 +2,6 @@
 
 Test running writer over example files and chosen snippets.
 """
-from __future__ import (division, print_function, absolute_import,
-                        unicode_literals)
 
 from os.path import join as pjoin, exists
 from glob import glob

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 ipython[notebook]>=4.0
 sphinx>=1.4
-numpy>=1.7.1
+numpy>=1.14
 matplotlib>=2.0
 sphinxtesters>=0.2
 texext

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ ipython[notebook]>=4.0
 sphinx>=1.4
 numpy>=1.7.1
 matplotlib>=2.0
-six>=1.10
 sphinxtesters>=0.2
 texext

--- a/scripts/nb2plots
+++ b/scripts/nb2plots
@@ -8,8 +8,6 @@ Example:
 Prints to stdout with UTF-8 encoding.
 """
 # vim: ft=python
-from __future__ import division, print_function, absolute_import
-
 from argparse import ArgumentParser
 
 from nb2plots.commands import bin_stdout

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ import os
 from os.path import join as pjoin, split as psplit, splitext
 import re
 
-import setuptools
-from distutils.core import setup
+from setuptools import setup
 
 import versioneer
 
@@ -116,5 +115,6 @@ setup(name='nb2plots',
                  'scripts/rst2md'],
       long_description = open('README.rst', 'rt').read(),
       install_requires = install_requires,
-      extras_require = {'test': test_requires}
+      extras_require = {'test': test_requires},
+      python_requires='>=3.7',
       )


### PR DESCRIPTION
* Remove __future__ imports
* Remove use of six
* Remove Python 2 check for stdout
* Remove use of LooseVersion