### PR TITLE
Update nbconvert path to ResourcesDict in runroles.py

### DIFF
--- a/nb2plots/runroles.py
+++ b/nb2plots/runroles.py
@@ -331,8 +331,8 @@ def fill_notebook(nb, timeout=30):
     preprocessor = nbc.preprocessors.execute.ExecutePreprocessor(
         timeout=timeout)
     preprocessor.enabled = True
-    res = nbc.exporter.ResourcesDict()
-    res['metadata'] = nbc.exporter.ResourcesDict()
+    res = nbc.exporters.exporter.ResourcesDict()
+    res['metadata'] = nbc.exporters.exporter.ResourcesDict()
     output_nb, _ = preprocessor(deepcopy(nb), res)
     return output_nb
 


### PR DESCRIPTION
Fixes #32 

nbconvert changed their import structure in v7.9.0 (replacing import * with import (<list of things>) and `ResourcesDict` no longer is available in `nbconvert.exporter`. Switched to `nbconvert.exporters.exporter`.

I think this new syntax will work for older versions of nbconvert. 
But the previous syntax stops working in nbconvert v7.9.0