### PR TITLE
tests: replace relative imports with absolute ones in test_from_notebook.py

### DIFF
--- a/nb2plots/tests/test_from_notebook.py
+++ b/nb2plots/tests/test_from_notebook.py
@@ -5,9 +5,9 @@ from os.path import dirname, join as pjoin
 
 import nbformat
 
-from ..from_notebook import (convert_nb, convert_nb_fname, to_doctests,
-                             has_mpl_inline, CODE_WITH_OUTPUT)
-from ..testing import stripeq
+from nb2plots.from_notebook import (convert_nb, convert_nb_fname, to_doctests,
+                                    has_mpl_inline, CODE_WITH_OUTPUT)
+from nb2plots.testing import stripeq
 
 
 DATA_PATH = pjoin(dirname(__file__), 'data')


### PR DESCRIPTION
This is part of Debian tests, where we run tests against the installed version of a module; being relative imports means tests wont find them, while making them absolute, they are detected properly